### PR TITLE
Validaciones: @NotNull/@Positive en precio + @Valid; 400 correcto

### DIFF
--- a/src/main/java/com/example/materiales_app/entity/Material.java
+++ b/src/main/java/com/example/materiales_app/entity/Material.java
@@ -1,7 +1,7 @@
 package com.example.materiales_app.entity;
 
 import jakarta.persistence.*;
-
+import jakarta.validation.constraints.*;
 import java.math.BigDecimal;
 
 @Entity
@@ -11,15 +11,18 @@ public class Material {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
-
+    @NotBlank(message = "El nomnbre es obligatorio" )  //Validation
     @Column(nullable = false, length = 120)
     String nombre;
 
+    @NotBlank(message = "La unidad es obligatoria" )  //Validation
     @Column(nullable = false, length = 20)
     String unidad;
 
+    @NotNull(message = "El precio es obligatorio" )  //Validation
+    @Positive(message="El precio debe ser mayor que CERO") //Validation
     @Column(nullable = false, precision = 12, scale = 2)
-    BigDecimal precio;
+    private BigDecimal precio;
 
     public Long getId() {
         return id;
@@ -33,8 +36,8 @@ public class Material {
         return nombre;
     }
 
-    public void setNombre(String nonbre) {
-        this.nombre = nonbre;
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
     }
 
     public String getUnidad() {

--- a/src/main/java/com/example/materiales_app/web/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/materiales_app/web/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.example.materiales_app.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(jakarta.validation.ConstraintViolationException.class)
+    public ResponseEntity<Map<String,Object>> onConstraintViolation(jakarta.validation.ConstraintViolationException ex){
+        Map<String,Object> body = new HashMap<>();
+        body.put("message","Validación de datos");
+        body.put("errors", ex.getConstraintViolations().stream()
+                .map(cv -> Map.of("property", cv.getPropertyPath().toString(), "error", cv.getMessage()))
+                .toList());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+}

--- a/src/main/java/com/example/materiales_app/web/MaterialController.java
+++ b/src/main/java/com/example/materiales_app/web/MaterialController.java
@@ -1,15 +1,15 @@
 package com.example.materiales_app.web;
 
-
 import com.example.materiales_app.entity.Material;
 import com.example.materiales_app.repo.MaterialRepository;
+import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Optional;
+
 
 @RestController
 @RequestMapping("/api/materiales")
@@ -21,8 +21,8 @@ public class MaterialController {
         this.repo = repo;
     }
 
-    @GetMapping
-    public Page listar(Pageable pageable) {
+    @GetMapping({"", "/"})
+    public Page<Material> listar(Pageable pageable) {
         return repo.findAll(pageable);
     }
 
@@ -32,21 +32,22 @@ public class MaterialController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @PostMapping
-    public ResponseEntity<Material> crear(@RequestBody Material m) {
+    @PostMapping({"", "/"})
+    public ResponseEntity<Material> crear(@Valid @RequestBody Material m) { //Agregando @Valid
         Material creado = repo.save(m);
         return ResponseEntity.status(HttpStatus.CREATED).body(creado);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<Material> actualizar(@PathVariable Long id, @RequestBody Material m) {
-        Optional<Material> opt = repo.findById(id);
-        if (opt.isEmpty()) return ResponseEntity.notFound().build();
-        Material db = opt.get();
-        db.setNombre(m.getNombre());
-        db.setUnidad(m.getUnidad());
-        db.setPrecio(m.getPrecio());
-        return ResponseEntity.ok(repo.save(db));
+    @PutMapping("/{id}") //Agregando @Valid
+    public ResponseEntity<Material> actualizar(@PathVariable Long id, @Valid @RequestBody Material m) {
+
+        return repo.findById(id).map(db -> {
+
+            db.setNombre(m.getNombre());
+            db.setUnidad(m.getUnidad());
+            db.setPrecio(m.getPrecio());
+            return ResponseEntity.ok(repo.save(db));
+        }).orElse(ResponseEntity.notFound().build());
 
     }
 


### PR DESCRIPTION
## Qué hace este PR
- Añade validaciones Bean Validation a `Material`:
  - `nombre`: @NotBlank
  - `unidad`: @NotBlank
  - `precio`: @NotNull + @Positive
- Aplica `@Valid` en `POST` y `PUT` para validar antes de persistir.
- Agrega `GlobalExceptionHandler` para devolver 400 con detalle de errores.
- Ajusta endpoints para aceptar `/api/materiales` y `/api/materiales/`.
- Tipado de `Page<Material>` en el listado.

## Endpoints afectados
- POST /api/materiales
- PUT  /api/materiales/{id}
- GET  /api/materiales (Pageable)
- DELETE /api/materiales/{id}

## Cómo probar (Postman)
1) **Inválido** (debe responder 400 con lista de errores):
```json
{ "nombre": "", "unidad": "", "precio": -5 }
